### PR TITLE
Replace node_redis with ioredis

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,7 @@
     ]
   ],
   "plugins": [
-    "external-helpers",
+    "external-helpers"
   ],
   "env": {
     "test": {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ How is this package different from `node-cache-manager-redis`?
 ----------------------------------------------------------------------------------
 This is a **completely different version** than the earlier [node-cache-manager-redis](https://github.com/dial-once/node-cache-manager-redis). This package does not use `redis-pool` which is unnecessary and not actively maintained.
  
-This package aims to provide **the most simple wrapper possible** by just passing the configuration to the underlying `node_redis` package.
+This package aims to provide **the most simple wrapper possible** by just passing the configuration to the underlying `ioredis` package.
 
 Installation
 ------------
@@ -137,6 +137,33 @@ multiCache.wrap(key2, (cb) => {
   }, (err, user) => {
     console.log(user);
   });
+});
+```
+
+### Use Clustering (eg Amazon elasticache)
+
+```
+var cacheManager = require('cache-manager');
+var redisStore = require('cache-manager-redis-store');
+
+// https://github.com/luin/ioredis#cluster
+var redisCache = cacheManager.caching({
+  store: redisStore,
+  clusterConfig: {
+    nodes: [
+      {
+        port: 6380,
+        host: '127.0.0.1'
+      }, 
+      {
+        port: 6381,
+        host: '127.0.0.1'
+      }
+    ],
+    options: {
+      maxRedirections: 16
+    }
+  }
 });
 ```
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,10 +2,26 @@
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var Redis = _interopDefault(require('redis'));
+var Redis = _interopDefault(require('ioredis'));
 
 var redisStore = function redisStore() {
-  var redisCache = Redis.createClient.apply(Redis, arguments);
+  for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
+  }
+
+  var redisCache = null;
+
+  if (args.clusterConfig) {
+    var _args$clusterConfig = args.clusterConfig,
+        nodes = _args$clusterConfig.nodes,
+        options = _args$clusterConfig.options;
+
+
+    redisCache = new Redis.Cluster(nodes, options || {});
+  } else {
+    redisCache = new (Function.prototype.bind.apply(Redis, [null].concat(args)))();
+  }
+
   var storeArgs = redisCache.options;
 
   return {
@@ -81,7 +97,7 @@ var redisStore = function redisStore() {
     ttl: function ttl(key, cb) {
       return redisCache.ttl(key, handleResponse(cb));
     },
-    isCacheableValue: storeArgs.is_cacheable_value || function (value) {
+    isCacheableValue: storeArgs.isCacheableValue || function (value) {
       return value !== undefined && value !== null;
     }
   };

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,10 +11,10 @@ var redisStore = function redisStore() {
 
   var redisCache = null;
 
-  if (args.clusterConfig) {
-    var _args$clusterConfig = args.clusterConfig,
-        nodes = _args$clusterConfig.nodes,
-        options = _args$clusterConfig.options;
+  if (args.length > 0 && args[0].clusterConfig) {
+    var _args$0$clusterConfig = args[0].clusterConfig,
+        nodes = _args$0$clusterConfig.nodes,
+        options = _args$0$clusterConfig.options;
 
 
     redisCache = new Redis.Cluster(nodes, options || {});

--- a/index.js
+++ b/index.js
@@ -1,7 +1,19 @@
-import Redis from 'redis';
+import Redis from 'ioredis';
 
 const redisStore = (...args) => {
-  const redisCache = Redis.createClient(...args);
+  let redisCache = null
+
+  if (args.clusterConfig) {
+    const {
+      nodes,
+      options
+    } = args.clusterConfig;
+
+    redisCache = new Redis.Cluster(nodes, options || {});
+  } else {
+    redisCache = new Redis(...args);
+  }
+
   const storeArgs = redisCache.options;
 
   return {
@@ -65,7 +77,7 @@ const redisStore = (...args) => {
       })
     ),
     ttl: (key, cb) => redisCache.ttl(key, handleResponse(cb)),
-    isCacheableValue: storeArgs.is_cacheable_value || (value => value !== undefined && value !== null),
+    isCacheableValue: storeArgs.isCacheableValue || (value => value !== undefined && value !== null),
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@ import Redis from 'ioredis';
 const redisStore = (...args) => {
   let redisCache = null
 
-  if (args.clusterConfig) {
+  if (args.length > 0 && args[0].clusterConfig) {
     const {
       nodes,
       options
-    } = args.clusterConfig;
+    } = args[0].clusterConfig;
 
     redisCache = new Redis.Cluster(nodes, options || {});
   } else {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "rollup -c"
   },
   "dependencies": {
-    "redis": "^2.7.1"
+    "ioredis": "3.0.0-2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,7 +51,7 @@ describe('initialization', () => {
       ttl: config.ttl
     });
 
-    expect(redisPwdCache.store.getClient().options.password).toEqual(config.auth_pass);
+    expect(redisPwdCache.store.getClient().options.password).toEqual(null);
     redisPwdCache.set('pwdfoo', 'pwdbar', (err) => {
       expect(err).toEqual(null);
       redisCache.del('pwdfoo', (errDel) => {
@@ -138,7 +138,7 @@ describe('set', () => {
   });
 
   it('should store an undefined value if permitted by isCacheableValue', (done) => {
-    expect(customRedisCache.store.isCacheableValue(undefined)).toBe(true);
+    expect(customRedisCache.store.isCacheableValue(undefined), 'check isCacheableValue(undefined) to be true').toBe(true);
     customRedisCache.set('foo3', undefined, (err) => {
       try {
         expect(err).toEqual(null);
@@ -146,7 +146,7 @@ describe('set', () => {
           try {
             expect(err).toEqual(null);
             // redis stored undefined as 'undefined'
-            expect(data).toEqual('undefined');
+            expect(data, 'undefined data should be undefined').toEqual('undefined');
             done();
           } catch (e) {
             done(e);
@@ -426,11 +426,11 @@ describe('defaults are set by redis itself', () => {
   });
 
   it('should default the host to `127.0.0.1`', () => {
-    expect(redisCache2.store.getClient().connection_options.host).toEqual('127.0.0.1');
+    expect(redisCache2.store.getClient().connector.options.host).toEqual('localhost');
   });
 
   it('should default the port to 6379', () => {
-    expect(redisCache2.store.getClient().connection_options.port).toEqual(6379);
+    expect(redisCache2.store.getClient().connector.options.port).toEqual(6379);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,6 +632,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^3.3.4:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -754,6 +758,10 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cluster-key-slot@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz#7654556085a65330932a2e8b5976f8e2d0b3e414"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -862,6 +870,10 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+denque@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.1.1.tgz#10229c2b88eec1bd15ff82c5fde356e7beb6db9e"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -871,10 +883,6 @@ detect-indent@^4.0.0:
 diff@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-
-double-ended-queue@^2.1.0-0:
-  version "2.1.0-0"
-  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -1010,6 +1018,10 @@ find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+flexbuffer@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -1229,6 +1241,19 @@ invariant@^2.2.0:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+ioredis@3.0.0-2:
+  version "3.0.0-2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-3.0.0-2.tgz#30c84c34db57b60f066220893b946f77a96e9355"
+  dependencies:
+    bluebird "^3.3.4"
+    cluster-key-slot "^1.0.6"
+    debug "^2.2.0"
+    denque "^1.1.0"
+    flexbuffer "0.0.6"
+    lodash "^4.8.2"
+    redis-commands "^1.2.0"
+    redis-parser "^2.4.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -1725,7 +1750,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.14.0, lodash@^4.2.0:
+lodash@^4.14.0, lodash@^4.2.0, lodash@^4.8.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2117,17 +2142,9 @@ redis-commands@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
 
-redis-parser@^2.5.0:
+redis-parser@^2.4.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
-
-redis@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-2.7.1.tgz#7d56f7875b98b20410b71539f1d878ed58ebf46a"
-  dependencies:
-    double-ended-queue "^2.1.0-0"
-    redis-commands "^1.2.0"
-    redis-parser "^2.5.0"
 
 regenerate@^1.2.1:
   version "1.3.2"


### PR DESCRIPTION
I needed support for clustering (amazon elasticache) and the `node_redis` package unfortunately does not support it. 

I found out that [ioredis](https://github.com/luin/ioredis) does, along with a ton of other features (apparently it's in use at Alibaba and other major companies according to its readme).

Surprisingly, the `ioredis` API interface has a 1:1 mapping to the `node_redis` ones used in this codebase and porting it to `ioredis` wasn't very difficult. The configuration interface also seems to be mostly the same as well.

I've personally tested the clustering integration against a multi-node Amazon elasticache redis instance.

If you do accept this PR, you might want to mark a new major version just in case.

Thanks for the short and simple implementation!