### PR TITLE
Fix: use keys() without pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ const redisStore = (...args) => {
         redisCache.flushdb(handleResponse(cb));
       })
     ),
-    keys: (pattern, cb) => (
+    keys: (pattern = '*', cb) => (
       new Promise((resolve, reject) => {
         if (typeof pattern === 'function') {
           cb = pattern;


### PR DESCRIPTION
This fix prevents the error below...

```
node_redis: Deprecated: The KEYS command contains a "undefined" argument.
This is converted to a "undefined" string now and will return an error from v.3.0 on.
Please handle this in your code to make sure everything works as you intended it to.
```