### PR TITLE
Add the option to pass a custom redis client to redisStore

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,14 @@
 import Redis from 'redis';
 
 const redisStore = (...args) => {
-  const redisCache = Redis.createClient(...args);
+  let redisCache
+
+  if (args.length > 0 && args[0].redisClient) {
+    redisCache = args[0].redisClient;
+  } else {
+    redisCache = Redis.createClient(...args);
+  }
+
   const storeArgs = redisCache.options;
 
   return {
@@ -142,7 +149,7 @@ const redisStore = (...args) => {
         if (!cb) {
           cb = (err, result) => (err ? reject(err) : resolve(result));
         }
-  
+
         redisCache.flushdb(handleResponse(cb));
       })
     ),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -63,6 +63,19 @@ describe('initialization', () => {
       });
     });
   });
+
+  it('should use provided redisClient if one is provided', () => {
+    const dbName = 'a_different_db';
+    const redisClient = Redis.createClient({ db: dbName });
+
+    const redisCacheWithCustomClient = cacheManager.caching({
+      store: redisStore,
+      redisClient,
+    });
+
+    expect(redisCacheWithCustomClient.store.getClient()).toEqual(redisClient);
+    expect(redisCacheWithCustomClient.store.getClient().options.db).toEqual(dbName);
+  });
 });
 
 describe('set', () => {
@@ -722,18 +735,5 @@ describe('wrap function', () => {
         )
           .then((user) => expect(user.id).toEqual(userId));
       });
-  });
-
-  it('should use provided redisClient if one is provided', () => {
-      const dbName = 'a_different_db';
-      const redisClient = Redis.createClient({ db: dbName });
-
-      const redisCacheWithCustomClient = cacheManager.caching({
-        store: redisStore,
-        redisClient,
-      });
-
-      expect(redisCacheWithCustomClient.store.getClient()).toEqual(redisClient)
-      expect(redisCacheWithCustomClient.store.getClient().options.db).toEqual(dbName)
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -733,7 +733,7 @@ describe('wrap function', () => {
         redisClient,
       });
 
-      expect(redisCacheWithCustomClient.store.getClient() === redisClient).toEqual(true)
+      expect(redisCacheWithCustomClient.store.getClient()).toEqual(redisClient)
       expect(redisCacheWithCustomClient.store.getClient().options.db).toEqual(dbName)
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,4 @@
+import Redis from 'redis';
 import cacheManager from 'cache-manager';
 import redisStore from '../index';
 
@@ -721,5 +722,18 @@ describe('wrap function', () => {
         )
           .then((user) => expect(user.id).toEqual(userId));
       });
+  });
+
+  it('should use provided redisClient if one is provided', () => {
+      const dbName = 'a_different_db';
+      const redisClient = Redis.createClient({ db: dbName });
+
+      const redisCacheWithCustomClient = cacheManager.caching({
+        store: redisStore,
+        redisClient,
+      });
+
+      expect(redisCacheWithCustomClient.store.getClient() === redisClient).toEqual(true)
+      expect(redisCacheWithCustomClient.store.getClient().options.db).toEqual(dbName)
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,8 +65,8 @@ describe('initialization', () => {
   });
 
   it('should use provided redisClient if one is provided', () => {
-    const dbName = 'a_different_db';
-    const redisClient = Redis.createClient({ db: dbName });
+    const ttl = 42;
+    const redisClient = Redis.createClient({ ttl });
 
     const redisCacheWithCustomClient = cacheManager.caching({
       store: redisStore,
@@ -74,7 +74,7 @@ describe('initialization', () => {
     });
 
     expect(redisCacheWithCustomClient.store.getClient()).toEqual(redisClient);
-    expect(redisCacheWithCustomClient.store.getClient().options.db).toEqual(dbName);
+    expect(redisCacheWithCustomClient.store.getClient().options.ttl).toEqual(ttl);
   });
 });
 


### PR DESCRIPTION
Aims to solve https://github.com/dabroek/node-cache-manager-redis-store/issues/7

- No breaking changes
- Tests