### PR TITLE
Update Typescript definitions to be more specific

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5,8 +5,8 @@ interface RedisStore extends Store {
     name: string;
     getClient: () => RedisClientType;
     isCacheableValue: any;
-    set: (key: any, value: any, options: any, cb: any) => Promise<any>;
-    get: (key: any, options: any, cb: any) => Promise<any>;
+    set: <T>(key: any, value: T, options?: any, cb?: function) => Promise<void>;
+    get: <T>(key: any, options?: any, cb?: function) => Promise<T | undefined>;
     del: (...args: any[]) => Promise<any>;
     mset: (...args: any[]) => Promise<any>;
     mget: (...args: any[]) => Promise<any>;


### PR DESCRIPTION
Should fix issue #53 by updating Typescript definitions in a non-breaking way.

Within NestJS, when registering the `CacheModule`, you can configure it as such:

```typescript
    CacheModule.registerAsync({
      isGlobal: true,
      useFactory: async (configService: ConfigService) => {
        return {
          store: await redisStore({
            socket: {
              host: configService.get('REDIS_HOST'),
              port: configService.get('REDIS_PORT'),
            },
          }),
        };
      },
    }),
```

In the future, issue #52 should be addressed by updating the function signatures in the code to properly match `Store`. This change is a stop-gap measure to unblock users of NestJS framework (and likely others).